### PR TITLE
Added max soil stats and information about the soil data structure.

### DIFF
--- a/Eliza.UI/Forms/DataForm.cs
+++ b/Eliza.UI/Forms/DataForm.cs
@@ -2,6 +2,7 @@
 using Eliza.UI.Widgets;
 using Eto.Forms;
 using System;
+using System.Collections.Specialized;
 
 namespace Eliza.UI.Forms
 {
@@ -100,7 +101,7 @@ namespace Eliza.UI.Forms
 
             var farmDataButton = new Button()
             {
-                Text = "Farm Data"
+                Text = "Increase Soil Stats"
             };
 
             farmDataButton.Click += FarmDataButton_Click;
@@ -307,7 +308,7 @@ namespace Eliza.UI.Forms
 
         private void FarmDataButton_Click(object sender, EventArgs e)
         {
-            throw new NotImplementedException();
+            this.MaxSoilStats(_saveData.saveData.farmData);
         }
 
         private void SupportMonsterDataButton_Click(object sender, EventArgs e)
@@ -315,11 +316,100 @@ namespace Eliza.UI.Forms
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Maxes out the friendship values of all monsters in your barn.
+        /// </summary>
+        /// <param name="statusData">The current Statusdata from the save file.</param>
         private void MaxMonsterFriendship(RF5StatusData statusData)
         {
-            foreach(var monster in statusData.FriendMonsterStatusDatas)
+            foreach (var monster in statusData.FriendMonsterStatusDatas)
             {
                 monster.LovePoint = 255;
+            }
+        }
+
+        /// <summary>
+        /// Kind of maxes out the soil stats. 
+        /// Soil stats are stored in four BitVector32 structures. Each structure contains 4 soil values a 8-bytes.
+        /// Variables labeled with 'Boost' are the ones the player can influence with items like greenifier.
+        /// Variables labeled with 'Lvl' are the experience points of the soil that increase with harvesting. Once they overflow they increase the base values.
+        /// Variables labeled with "base" are the base values of the soil.
+        /// Other variables kind of influence the other stats in a weird way.
+        /// This method only changes Boost and Lvl stats and ignores the others.
+        /// </summary>
+        /// <param name="farmData">The current farm data from the save file</param>
+        private void MaxSoilStats(RF5FarmData farmData)
+        {
+            foreach (var soil in farmData.Soil)
+            {
+                
+                BitVector32 soil0 = new BitVector32((int)soil.SI0.data);
+                BitVector32.Section soil0_1 = BitVector32.CreateSection(255);
+                BitVector32.Section growthBoost = BitVector32.CreateSection(255, soil0_1);
+                BitVector32.Section soil0_3 = BitVector32.CreateSection(255, growthBoost);
+                BitVector32.Section qualityBoost = BitVector32.CreateSection(255, soil0_3);
+
+                // Kind of influences growthBoost and sizeBoost. Won't be changed.
+                //soil0[soil0_1] = 0;
+                // Kind of influences a lot. Won't be changed.
+                //soil0[soil0_3] = 192;
+                
+                // Growth Boost. In-game maximum is 5.
+                soil0[growthBoost] = 5;
+                // Quality boost. In-game maximum is 127.
+                soil0[qualityBoost] = 127;
+
+                soil.SI0.data = (uint)soil0.Data;
+
+                
+                BitVector32 soil1 = new BitVector32((int)soil.SI1.data);
+                BitVector32.Section sizeMulit = BitVector32.CreateSection(255);
+                BitVector32.Section defenseBoost = BitVector32.CreateSection(255, sizeMulit);
+                BitVector32.Section healthBoost = BitVector32.CreateSection(255, defenseBoost);
+                BitVector32.Section sizeBoost = BitVector32.CreateSection(255, healthBoost);
+
+                // This and sizeBoost influence each other. Won't change this one.
+                //soil1[sizeMulit] = 255;
+
+                // Defense maxes out at 253. Kind of resets sizeBoost when set to a higher value.
+                soil1[defenseBoost] = 253;
+                soil1[healthBoost] = 255;
+                // Max value is 126. Greater value reduces in-game value.
+                soil1[sizeBoost] = 126;
+
+                soil.SI1.data = (uint)soil1.Data;
+
+
+                BitVector32 soil2 = new BitVector32((int)soil.SI2.data);
+                BitVector32.Section numberBase = BitVector32.CreateSection(255);
+                BitVector32.Section sizeBase = BitVector32.CreateSection(255, numberBase);
+                BitVector32.Section qualityBase = BitVector32.CreateSection(255, sizeBase);
+                BitVector32.Section speedLvl = BitVector32.CreateSection(255, qualityBase);
+
+                // Won't touch base values.
+                //soil2[numberBase] = 0;
+                //soil2[sizeBase] = 0;
+                //soil2[qualityBase] = 0;
+                soil2[speedLvl] = 255;
+
+                soil.SI2.data = (uint)soil2.Data;
+
+                           
+                BitVector32 soil3 = new BitVector32(0);
+                BitVector32.Section numberLvl = BitVector32.CreateSection(255);
+                BitVector32.Section qualityLvl = BitVector32.CreateSection(255, numberLvl);
+                BitVector32.Section sizeLvl = BitVector32.CreateSection(255, qualityLvl);
+                BitVector32.Section speedBase = BitVector32.CreateSection(255, sizeLvl);
+
+                // Max out soil experience points.
+                soil3[numberLvl] = 255;
+                soil3[qualityLvl] = 255;
+                soil3[sizeLvl] = 255;
+
+                // Won't touch base values.
+                //soil3[speedBase] = 0;
+
+                soil.SI3.data = (uint)soil3.Data;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 # Eliza
+
  A cross-platform (RF5) Rune Factory 5 Save Editor
 
 ## Building
+
 1. Install the [.NET 5.0+ SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
 2. Download the repository by clicking the ``Clone`` dropdownbox and clicking either ``Download Zip`` or ``Open with Github Desktop``.
-3. Extract the raw contents of the repository. 
+3. Extract the raw contents of the repository.
 4. Open a console (command prompt, git bash, etc.) in the repository folder, and run ``dotnet publish [TargetPlatform] -c Release`` with ``[TargetPlatform]`` being either ``Eliza.Windows`` (Windows), ``Eliza.Linux`` (Linux), or ``Eliza.Mac`` (MacOS) to build the binary.
- 
+
 ## Maintainers
 
-
 ## Credits and Thanks
+
 - [SPICA](https://github.com/gdkchan/SPICA) for base for serialization
+- [SinsofSloth](https://github.com/SinsofSloth) for the original creation of the save editor.
 - Blazagon for name data
 - bluedart and other testers
-- Item list from: https://docs.google.com/spreadsheets/d/13-ql1gKkne1F4c9rzgAw3woR8PXR6_vb 
+- Item list from: <https://docs.google.com/spreadsheets/d/13-ql1gKkne1F4c9rzgAw3woR8PXR6_vb>
+
+## Soil stats
+
+Soil stats are stored in four BitVector32 structures. Each structure contains 4 soil values a 8-bytes.
+Variables labeled with 'Boost' are the ones the player can influence with items like greenifier.
+Variables labeled with 'Lvl' are the experience points of the soil that increase with harvesting. Once they overflow they increase the base values.
+Variables labeled with "base" are the base values of the soil.
+Other variables kind of influence the other stats in a weird way.<br>
+
+### Structure of the soil values
+
+|Name|First Byte|Second Byte|Third Byte|Fourth Byte|
+|---|---|---|---|---|
+|SI0|Quality Boost|Some kind of multiplier?|Growth Boost|Some kind of multiplier?|
+|SI1|Size Boost|Health Boost|Defense Boost|Some kind of multiplier?|
+|SI2|Speed Lvl Exp|Base quality|Base Size|Base Number of Crops|
+|SI3|Base Speed|Size Lvl Exp|Quality Lvl Exp|Number of Crops Lvl Exp|


### PR DESCRIPTION
**Added a way to increase the stats of the soil. Only the stats the player can influence (with items like Greenifier) and the level experience of the soil is maxed out. Base stats and multipliers are not touched.**

## Technical Information
Soil stats are stored in four BitVector32 structures. Each structure contains 4 soil values a 8-bytes.
Variables labeled with 'Boost' are the ones the player can influence with items like Greenifier.
Variables labeled with 'Lvl' are the experience points of the soil that increase with harvesting. Once they overflow they increase the base values.
Variables labeled with "base" are the base values of the soil.
Other variables kind of influence the other stats in a weird way.

### Structure of the soil values

|Name|First Byte|Second Byte|Third Byte|Fourth Byte|
|---|---|---|---|---|
|SI0|Quality Boost|Some kind of multiplier?|Growth Boost|Some kind of multiplier?|
|SI1|Size Boost|Health Boost|Defense Boost|Some kind of multiplier?|
|SI2|Speed Lvl Exp|Base quality|Base Size|Base Number of Crops|
|SI3|Base Speed|Size Lvl Exp|Quality Lvl Exp|Number of Crops Lvl Exp|